### PR TITLE
fix: allow app start with ethernet only (#3)

### DIFF
--- a/hyprltm-net.sh
+++ b/hyprltm-net.sh
@@ -224,12 +224,25 @@ tr_edit_password_prompt='Enter new password:'
 # --- Global Variables ---
 program_name="$(basename "$0")"
 LOADING_ROFI_PID=""
-mapfile -t interfaces < <(nmcli --colors no -t -f TYPE,DEVICE device status | awk -F ':' '$1 == "wifi" {print $2}')
-if [ -z "${interfaces[0]}" ]; then
-	echo "$program_name: No Wi-Fi interfaces detected." >&2
+
+# Detect interfaces separately
+mapfile -t wifi_interfaces < <(nmcli --colors no -t -f TYPE,DEVICE device status | awk -F ':' '$1 == "wifi" {print $2}')
+mapfile -t ethernet_interfaces < <(nmcli --colors no -t -f TYPE,DEVICE device status | awk -F ':' '$1 == "ethernet" {print $2}')
+
+if [ -z "${wifi_interfaces[0]}" ] && [ -z "${ethernet_interfaces[0]}" ]; then
+	echo "$program_name: No Wi-Fi or Ethernet interfaces detected." >&2
 	exit 2
 fi
-interface_to_use="${interfaces[0]}"
+
+# Primary interface for Wi-Fi operations
+if [ -n "${wifi_interfaces[0]}" ]; then
+    interfaces=("${wifi_interfaces[@]}")
+    interface_to_use="${wifi_interfaces[0]}"
+else
+    # Fallback to ethernet for general status if no wifi exists
+    interfaces=("${ethernet_interfaces[@]}")
+    interface_to_use="${ethernet_interfaces[0]}"
+fi
 
 # --- Helper Functions ---
 


### PR DESCRIPTION
This PR is my take on issue #3. It simpy adds an or condition to check for "ethernet" interfaces as well. With this change the application will not only start when there is a wifi interface available.